### PR TITLE
Wrapped the theme provider on the app

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,10 +1,24 @@
 import React from "react";
 import Navbar from "./components/Navbar";
+import {createTheme, ThemeProvider} from '@mui/material/styles';
+
+const theme = createTheme({
+    palette: {
+        primary: {
+            main: '#e8d7a7'
+        },
+        secondary: {
+            main: '#f2e9ce'
+        }
+    },
+});
 
 function App() {
     return (
         <div>
-            <Navbar/>
+            <ThemeProvider theme={theme}>
+                <Navbar/>
+            </ThemeProvider>
         </div>
     );
 }

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -8,15 +8,6 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-import { createTheme, ThemeProvider } from '@mui/material/styles';
-
-const theme = createTheme({
-    palette: {
-        primary: {
-            main: '#e8d7a7'
-        }
-    },
-});
 
 function Navbar() {
     const [value, setValue] = React.useState('1');
@@ -26,30 +17,29 @@ function Navbar() {
     };
     return (
         <div>
-            <ThemeProvider theme={theme}>
-                <Box sx={{ flexGrow: 1 }}>
-                    <AppBar position="static" color="primary">
-                        <Toolbar>
-                            <Typography variant="h6" component="div" sx={{ flexGrow: 1 }}>
-                                NEWS APP
-                            </Typography>
-                            <Button color="inherit" disabled>The biggest news platform</Button>
-                        </Toolbar>
-                    </AppBar>
-                </Box>
-                <Box sx={{width: '100%', typography: 'body1'}}>
-                    <TabContext value={value}>
-                        <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
-                            <TabList onChange={handleChange} aria-label="lab API tabs example" color="primary">
-                                <Tab label="Main Page" value="1"/>
-                            </TabList>
-                        </Box>
-                        <TabPanel value="1">
-                            The news list will go here
-                        </TabPanel>
-                    </TabContext>
-                </Box>
-            </ThemeProvider>
+
+            <Box sx={{flexGrow: 1}}>
+                <AppBar position="static" color="secondary">
+                    <Toolbar>
+                        <Typography variant="h6" component="div" sx={{flexGrow: 1}}>
+                            NEWS APP
+                        </Typography>
+                        <Button color="inherit" disabled>The biggest news platform</Button>
+                    </Toolbar>
+                </AppBar>
+            </Box>
+            <Box sx={{width: '100%', typography: 'body1'}}>
+                <TabContext value={value}>
+                    <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
+                        <TabList onChange={handleChange} aria-label="lab API tabs example" color="primary">
+                            <Tab label="Main Page" value="1"/>
+                        </TabList>
+                    </Box>
+                    <TabPanel value="1">
+                        The news list will go here
+                    </TabPanel>
+                </TabContext>
+            </Box>
         </div>
     );
 }


### PR DESCRIPTION
The theme provider of the MUI color palette was added to the whole application wrapping all of the components inside of the App file.
This was made so the usage of the theme can be implemented on the whole application and to make future components and features easier.

![image](https://user-images.githubusercontent.com/56558009/206164601-e6f3bb71-557f-48f4-8b76-5db4dd27cb29.png)
