### PR TITLE
Implementation of single report page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import {createTheme, ThemeProvider} from '@mui/material/styles';
 import Page from "./components/Page";
 import {BrowserRouter, Routes, Route} from "react-router-dom";
+import Navbar from "./components/Navbar";
+import Footer from "./components/Footer";
+import SingleReport from "./components/SingleReport";
 
 const theme = createTheme({
     palette: {
@@ -19,9 +22,12 @@ function App() {
     return (
         <ThemeProvider theme={theme}>
             <BrowserRouter>
+                <Navbar/>
                 <Routes>
                     <Route path="/" element={<Page/>}></Route>
+                    <Route path="/report" element={<SingleReport/>}></Route>
                 </Routes>
+                <Footer/>
             </BrowserRouter>
         </ThemeProvider>
     );

--- a/src/components/Cards.tsx
+++ b/src/components/Cards.tsx
@@ -13,7 +13,7 @@ function Cards(props) {
     const navigate = useNavigate();
 
     function handleNavigate() {
-        navigate("/");
+        navigate("/report");
     }
 
     return (

--- a/src/components/Comment.tsx
+++ b/src/components/Comment.tsx
@@ -3,7 +3,7 @@ import Avatar from "@mui/material/Avatar";
 import Grid from '@mui/material/Grid';
 import Box from '@mui/material/Box';
 
-function CommentList(props) {
+function Comment(props) {
     const date = new Date().toDateString();
     return (
         <div>
@@ -25,4 +25,4 @@ function CommentList(props) {
     );
 }
 
-export default CommentList;
+export default Comment;

--- a/src/components/CommentForm.tsx
+++ b/src/components/CommentForm.tsx
@@ -1,0 +1,32 @@
+import React from "react";
+import Grid from "@mui/material/Grid";
+import TextField from "@mui/material/TextField";
+import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
+
+function CommentForm() {
+    function handleComment() {
+        alert("Clicked to comment");
+    }
+    return (
+        <div>
+            <Box sx={{flexGrow: 1}}>
+                <br/>
+                <Grid container spacing={2}>
+                    <Grid item xs={12} sm={12} md={8} lg={8}>
+                        <TextField id="outlined-size-small" label="Enter your comment here" variant="outlined"
+                                   size="small"
+                                   sx={{width: 1}}/>
+                    </Grid>
+                    <Grid item xs={12} sm={12} md={4} lg={4}>
+                        <Button
+                            onClick={handleComment}
+                            sx={{backgroundColor: "#e8d7a7", color: 'text.secondary', borderRadius: 0}}>COMMENT</Button>
+                    </Grid>
+                </Grid>
+            </Box>
+        </div>
+    );
+}
+
+export default CommentForm;

--- a/src/components/CommentList.tsx
+++ b/src/components/CommentList.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import Avatar from "@mui/material/Avatar";
+import Grid from '@mui/material/Grid';
+import Box from '@mui/material/Box';
+
+function CommentList(props) {
+    const date = new Date().toDateString();
+    return (
+        <div>
+            <Grid container spacing={2}>
+                <Grid item xs={12} sm={12} md={2}>
+                    <Avatar alt={props.name} src="/static/images/avatar/1.jpg" />
+                </Grid>
+                <Grid item xs={12} sm={12} md={2}>
+                    <p>{props.name}</p>
+                </Grid>
+                <Grid item xs={12} sm={12} md={6}>
+                    <p>This is the comment text here!</p>
+                </Grid>
+                <Grid item xs={12} sm={12} md={2}>
+                    <p>{date}</p>
+                </Grid>
+            </Grid>
+        </div>
+    );
+}
+
+export default CommentList;

--- a/src/components/CommentsSection.tsx
+++ b/src/components/CommentsSection.tsx
@@ -17,18 +17,17 @@ function CommentsSection(props) {
                     HIDE COMMENTS
                 </Button>
             }
-            {props.showComments ?
+            {props.showComments &&
                 <Box>
                     <CommentForm/>
-                </Box> : null
+                </Box>
             }
-            {props.showComments ? props.names.map((name, key) => (
+            {props.showComments && props.names.map((name, key) => (
                     <Box key={key}>
                         <br/>
                         <Comment name = {name}/>
                     </Box>
                 ))
-                : null
             }
         </div>
     );

--- a/src/components/CommentsSection.tsx
+++ b/src/components/CommentsSection.tsx
@@ -1,0 +1,37 @@
+import React from "react";
+import Button from "@mui/material/Button";
+import Box from "@mui/material/Box";
+import CommentForm from "./CommentForm";
+import Comment from "./Comment";
+
+function CommentsSection(props) {
+    return(
+        <div>
+            {!props.showComments ?
+                <Button sx={{backgroundColor: "#e8d7a7", color: 'text.secondary', borderRadius: 0}}
+                        onClick={() => props.setShowComments(true)}>
+                    COMMENTS
+                </Button> :
+                <Button sx={{backgroundColor: "#e8d7a7", color: 'text.secondary', borderRadius: 0}}
+                        onClick={() => props.setShowComments(false)}>
+                    HIDE COMMENTS
+                </Button>
+            }
+            {props.showComments ?
+                <Box>
+                    <CommentForm/>
+                </Box> : null
+            }
+            {props.showComments ? props.names.map((name, key) => (
+                    <Box key={key}>
+                        <br/>
+                        <Comment name = {name}/>
+                    </Box>
+                ))
+                : null
+            }
+        </div>
+    );
+}
+
+export default CommentsSection;

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,21 +1,11 @@
 import React from "react";
 import Box from '@mui/material/Box';
-import Tab from '@mui/material/Tab';
-import TabContext from '@mui/lab/TabContext';
-import TabList from '@mui/lab/TabList';
-import TabPanel from '@mui/lab/TabPanel';
 import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
-import News from "./News";
 
 function Navbar() {
-    const [value, setValue] = React.useState('1');
-
-    const handleChange = (event, newValue) => {
-        setValue(newValue);
-    };
     return (
         <div>
             <Box sx={{flexGrow: 1}}>
@@ -27,18 +17,6 @@ function Navbar() {
                         <Button color="inherit" disabled>The biggest news platform</Button>
                     </Toolbar>
                 </AppBar>
-            </Box>
-            <Box sx={{width: '100%', typography: 'body1'}}>
-                <TabContext value={value}>
-                    <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
-                        <TabList onChange={handleChange} aria-label="lab API tabs example" color="primary">
-                            <Tab label="Main Page" value="1"/>
-                        </TabList>
-                    </Box>
-                    <TabPanel value="1">
-                        <News/>
-                    </TabPanel>
-                </TabContext>
             </Box>
         </div>
     );

--- a/src/components/News.tsx
+++ b/src/components/News.tsx
@@ -1,7 +1,5 @@
 import React from 'react';
 import Cards from "./Cards";
-import Box from '@mui/material/Box';
-import Paper from '@mui/material/Paper';
 import Grid from '@mui/material/Grid';
 
 function News() {

--- a/src/components/Page.tsx
+++ b/src/components/Page.tsx
@@ -1,12 +1,31 @@
 import React from "react";
-import Navbar from "./Navbar";
-import Footer from "./Footer";
+import News from "./News";
+import TabContext from "@mui/lab/TabContext";
+import Box from "@mui/material/Box";
+import TabList from "@mui/lab/TabList";
+import Tab from "@mui/material/Tab";
+import TabPanel from "@mui/lab/TabPanel";
 
 function Page() {
+    const [value, setValue] = React.useState('1');
+
+    const handleChange = (event, newValue) => {
+        setValue(newValue);
+    };
     return (
         <div>
-            <Navbar/>
-            <Footer/>
+            <Box sx={{width: '100%', typography: 'body1'}}>
+                <TabContext value={value}>
+                    <Box sx={{borderBottom: 1, borderColor: 'divider'}}>
+                        <TabList onChange={handleChange} aria-label="lab API tabs example" color="primary">
+                            <Tab label="Main Page" value="1"/>
+                        </TabList>
+                    </Box>
+                    <TabPanel value="1">
+                        <News/>
+                    </TabPanel>
+                </TabContext>
+            </Box>
         </div>
     );
 }

--- a/src/components/SingleReport.tsx
+++ b/src/components/SingleReport.tsx
@@ -5,24 +5,11 @@ import {CardActionArea} from "@mui/material";
 import CardMedia from "@mui/material/CardMedia";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
-import Button from "@mui/material/Button";
 import Card from "@mui/material/Card";
-import CommentForm from "./CommentForm";
-import CommentList from "./CommentList";
+import {text} from "../data/Data";
+import CommentsSection from "./CommentsSection";
 
 function SingleReport() {
-    const text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer iaculis quis ex vel mattis. " +
-        "Etiam eu augue commodo, efficitur justo at, egestas turpis. Nulla congue, magna ut dictum lacinia, massa quam " +
-        "malesuada neque, ut varius lectus augue ac enim. Sed tincidunt turpis id lacus blandit, id rutrum nibh iaculis. " +
-        "In urna mi, feugiat id eros at, euismod vulputate sem. Cras vitae elit vel lacus posuere varius. " +
-        "Phasellus pretium rutrum massa, vitae facilisis dui fringilla ut. Aenean mattis justo in tortor semper venenatis. " +
-        "Phasellus laoreet nibh vel ligula semper, sit amet elementum dui rutrum.\n" +
-        "\n" +
-        "Nullam in gravida urna. Praesent vel purus ipsum. Fusce elementum, odio quis convallis varius, ipsum dui efficitur nulla," +
-        "et semper urna est nec urna. Donec a commodo odio. Etiam orci turpis, dapibus vitae dolor non, aliquet pretium massa." +
-        " Morbi lobortis pretium sem, vel pellentesque nibh suscipit vel. Nullam efficitur justo sed congue ornare. " +
-        "Duis auctor sodales risus, at posuere elit iaculis a. Aenean vel nibh magna.";
-
     const names = ["Commenter1", "Commenter2", "James Reed", "Greg Oden"]
 
     const [showComments, setShowComments] = useState(false);
@@ -53,29 +40,7 @@ function SingleReport() {
                                 <Typography variant="body2" color="text.secondary">
                                     <p>Author - Name</p>
                                 </Typography>
-                                {!showComments ?
-                                    <Button sx={{backgroundColor: "#e8d7a7", color: 'text.secondary', borderRadius: 0}}
-                                            onClick={() => setShowComments(true)}>
-                                        COMMENTS
-                                    </Button> :
-                                    <Button sx={{backgroundColor: "#e8d7a7", color: 'text.secondary', borderRadius: 0}}
-                                            onClick={() => setShowComments(false)}>
-                                        HIDE COMMENTS
-                                    </Button>
-                                }
-                                {showComments ?
-                                    <Box>
-                                        <CommentForm/>
-                                    </Box> : null
-                                }
-                                {showComments ? names.map((name, key) => (
-                                        <Box key={key}>
-                                            <br/>
-                                            <CommentList name = {name}/>
-                                        </Box>
-                                    ))
-                                     : null
-                                }
+                                <CommentsSection showComments = {showComments} setShowComments = {setShowComments} names = {names}/>
                                 <hr/>
                                 <Typography variant="body2" color="text.secondary">
                                     <small>Copyright - NewsApp 2022</small>

--- a/src/components/SingleReport.tsx
+++ b/src/components/SingleReport.tsx
@@ -1,0 +1,92 @@
+import React, {useState} from "react";
+import Grid from "@mui/material/Grid";
+import Box from "@mui/material/Box";
+import {CardActionArea} from "@mui/material";
+import CardMedia from "@mui/material/CardMedia";
+import CardContent from "@mui/material/CardContent";
+import Typography from "@mui/material/Typography";
+import Button from "@mui/material/Button";
+import Card from "@mui/material/Card";
+import CommentForm from "./CommentForm";
+import CommentList from "./CommentList";
+
+function SingleReport() {
+    const text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer iaculis quis ex vel mattis. " +
+        "Etiam eu augue commodo, efficitur justo at, egestas turpis. Nulla congue, magna ut dictum lacinia, massa quam " +
+        "malesuada neque, ut varius lectus augue ac enim. Sed tincidunt turpis id lacus blandit, id rutrum nibh iaculis. " +
+        "In urna mi, feugiat id eros at, euismod vulputate sem. Cras vitae elit vel lacus posuere varius. " +
+        "Phasellus pretium rutrum massa, vitae facilisis dui fringilla ut. Aenean mattis justo in tortor semper venenatis. " +
+        "Phasellus laoreet nibh vel ligula semper, sit amet elementum dui rutrum.\n" +
+        "\n" +
+        "Nullam in gravida urna. Praesent vel purus ipsum. Fusce elementum, odio quis convallis varius, ipsum dui efficitur nulla," +
+        "et semper urna est nec urna. Donec a commodo odio. Etiam orci turpis, dapibus vitae dolor non, aliquet pretium massa." +
+        " Morbi lobortis pretium sem, vel pellentesque nibh suscipit vel. Nullam efficitur justo sed congue ornare. " +
+        "Duis auctor sodales risus, at posuere elit iaculis a. Aenean vel nibh magna.";
+
+    const names = ["Commenter1", "Commenter2", "James Reed", "Greg Oden"]
+
+    const [showComments, setShowComments] = useState(false);
+
+    return (
+        <div>
+            <Box sx={{flexGrow: 1}}>
+                <Grid container>
+                    <Grid item xs={12}>
+                        <Card>
+                            <CardActionArea>
+                                <CardMedia
+                                    component="img"
+                                    height="500"
+                                    image="https://www.thediaryofanomad.com/wp-content/w3-webp/uploads/2020/04/london-photo-spots-big-ben-1.jpgw3.webp"
+                                    alt="image"
+                                />
+                            </CardActionArea>
+                            <CardContent>
+                                <Typography gutterBottom variant="h5" component="div">
+                                    <h1>
+                                        Title
+                                    </h1>
+                                </Typography>
+                                <Typography variant="body2" color="text.secondary">
+                                    {text}
+                                </Typography>
+                                <Typography variant="body2" color="text.secondary">
+                                    <p>Author - Name</p>
+                                </Typography>
+                                {!showComments ?
+                                    <Button sx={{backgroundColor: "#e8d7a7", color: 'text.secondary', borderRadius: 0}}
+                                            onClick={() => setShowComments(true)}>
+                                        COMMENTS
+                                    </Button> :
+                                    <Button sx={{backgroundColor: "#e8d7a7", color: 'text.secondary', borderRadius: 0}}
+                                            onClick={() => setShowComments(false)}>
+                                        HIDE COMMENTS
+                                    </Button>
+                                }
+                                {showComments ?
+                                    <Box>
+                                        <CommentForm/>
+                                    </Box> : null
+                                }
+                                {showComments ? names.map((name, key) => (
+                                        <Box key={key}>
+                                            <br/>
+                                            <CommentList name = {name}/>
+                                        </Box>
+                                    ))
+                                     : null
+                                }
+                                <hr/>
+                                <Typography variant="body2" color="text.secondary">
+                                    <small>Copyright - NewsApp 2022</small>
+                                </Typography>
+                            </CardContent>
+                        </Card>
+                    </Grid>
+                </Grid>
+            </Box>
+        </div>
+    );
+}
+
+export default SingleReport;

--- a/src/components/SingleReport.tsx
+++ b/src/components/SingleReport.tsx
@@ -6,7 +6,7 @@ import CardMedia from "@mui/material/CardMedia";
 import CardContent from "@mui/material/CardContent";
 import Typography from "@mui/material/Typography";
 import Card from "@mui/material/Card";
-import {text} from "../data/Data";
+import {SINGLE_REPORT_TEXT}  from "../data/Data";
 import CommentsSection from "./CommentsSection";
 
 function SingleReport() {
@@ -35,7 +35,7 @@ function SingleReport() {
                                     </h1>
                                 </Typography>
                                 <Typography variant="body2" color="text.secondary">
-                                    {text}
+                                    {SINGLE_REPORT_TEXT}
                                 </Typography>
                                 <Typography variant="body2" color="text.secondary">
                                     <p>Author - Name</p>

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -1,0 +1,11 @@
+export const text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer iaculis quis ex vel mattis. " +
+    "Etiam eu augue commodo, efficitur justo at, egestas turpis. Nulla congue, magna ut dictum lacinia, massa quam " +
+    "malesuada neque, ut varius lectus augue ac enim. Sed tincidunt turpis id lacus blandit, id rutrum nibh iaculis. " +
+    "In urna mi, feugiat id eros at, euismod vulputate sem. Cras vitae elit vel lacus posuere varius. " +
+    "Phasellus pretium rutrum massa, vitae facilisis dui fringilla ut. Aenean mattis justo in tortor semper venenatis. " +
+    "Phasellus laoreet nibh vel ligula semper, sit amet elementum dui rutrum.\n" +
+    "\n" +
+    "Nullam in gravida urna. Praesent vel purus ipsum. Fusce elementum, odio quis convallis varius, ipsum dui efficitur nulla," +
+    "et semper urna est nec urna. Donec a commodo odio. Etiam orci turpis, dapibus vitae dolor non, aliquet pretium massa." +
+    " Morbi lobortis pretium sem, vel pellentesque nibh suscipit vel. Nullam efficitur justo sed congue ornare. " +
+    "Duis auctor sodales risus, at posuere elit iaculis a. Aenean vel nibh magna.";

--- a/src/data/Data.js
+++ b/src/data/Data.js
@@ -1,4 +1,4 @@
-export const text = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer iaculis quis ex vel mattis. " +
+export const SINGLE_REPORT_TEXT = "Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer iaculis quis ex vel mattis. " +
     "Etiam eu augue commodo, efficitur justo at, egestas turpis. Nulla congue, magna ut dictum lacinia, massa quam " +
     "malesuada neque, ut varius lectus augue ac enim. Sed tincidunt turpis id lacus blandit, id rutrum nibh iaculis. " +
     "In urna mi, feugiat id eros at, euismod vulputate sem. Cras vitae elit vel lacus posuere varius. " +


### PR DESCRIPTION
The single report page was implemented with static data to serve the purpose of future data.
It was implemented to have three sections. The first is the headline photo, the second is the report text and title and the third sections are the comment form and comment list sections.
All of these sections were broken into smaller components which are used through this PR.

This first screenshot shows the first two sections. The comments button has the functionality to open the comments sections whichis shown in the next screenshot.
![image](https://user-images.githubusercontent.com/56558009/206416010-1869b48d-dd5b-4f4a-af84-49cfe703a2a1.png)

Comments section:
![image](https://user-images.githubusercontent.com/56558009/206415935-8338852c-f86f-416b-a953-633f1a76bc34.png)
