### PR TITLE
Navbar redesign

### DIFF
--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -4,6 +4,8 @@ import AppBar from '@mui/material/AppBar';
 import Toolbar from '@mui/material/Toolbar';
 import Typography from '@mui/material/Typography';
 import Button from '@mui/material/Button';
+import NewspaperIcon from '@mui/icons-material/Newspaper';
+import Link from '@mui/material/Link';
 
 function Navbar() {
     return (
@@ -11,8 +13,13 @@ function Navbar() {
             <Box sx={{flexGrow: 1}}>
                 <AppBar position="static" color="secondary">
                     <Toolbar>
+                        <Link href="/" color="inherit">
+                            <NewspaperIcon sx={{ display: { xs: 'none', md: 'flex' }, mr: 1 }} />
+                        </Link>
                         <Typography variant="h6" component="div" sx={{flexGrow: 1}}>
-                            NEWS APP
+                            <Link href="/" color="inherit" underline="none">
+                                <b>NEWS APP</b>
+                            </Link>
                         </Typography>
                         <Button color="inherit" disabled>The biggest news platform</Button>
                     </Toolbar>


### PR DESCRIPTION
The navbar was given a simple redesign. The application name now has a logo and both the logo and app name have a more presentable look and give a link to the home page.

![image](https://user-images.githubusercontent.com/56558009/206461543-43100d7d-1bc0-4b06-bf5b-a13227b82e0c.png)
