### PR TITLE
Created error page and notifications

### DIFF
--- a/src/components/comments/CommentsSection.tsx
+++ b/src/components/comments/CommentsSection.tsx
@@ -4,10 +4,13 @@ import Box from '@mui/material/Box';
 import CommentForm from './CommentForm';
 import Comment from './Comment';
 import { getAllComments } from '../../service/CommentService';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
 
 function CommentsSection() {
   const [showComments, setShowComments] = useState(false);
   const [comments, setComments] = useState([]);
+  const [error, setError] = useState(false);
 
   function handleGetAllComments(controller) {
     getAllComments(controller)
@@ -15,7 +18,12 @@ function CommentsSection() {
         setComments(res.data.comments);
       })
       .catch((err) => {
-        console.log(err);
+        if (err.code === 'ERR_CANCELED') {
+          console.log(err);
+        } else {
+          console.log(err);
+          setError(true);
+        }
       });
   }
 
@@ -70,6 +78,13 @@ function CommentsSection() {
               </div>
             ))}
           </Box>
+          {error && (
+            <Snackbar anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }} open={error}>
+              <Alert severity="error" sx={{ width: '100%' }}>
+                There has been a problem with loading the data!
+              </Alert>
+            </Snackbar>
+          )}
           <br />
         </div>
       )}

--- a/src/components/error/SomethingWentWrong.tsx
+++ b/src/components/error/SomethingWentWrong.tsx
@@ -1,0 +1,41 @@
+import Grid from '@mui/material/Grid';
+import React from 'react';
+import './somethingWentWrong.css';
+import ContactSupportIcon from '@mui/icons-material/ContactSupport';
+import NewReleasesIcon from '@mui/icons-material/NewReleases';
+
+interface Props {
+  errors: string;
+}
+function SomethingWentWrong(props: Props) {
+  return (
+    <div>
+      <Grid container sx={{ textAlign: 'center', backgroundColor: 'primary.light' }} rowSpacing={2}>
+        <Grid item xs={12} sx={{ fontSize: 'large' }}>
+          <img src="https://cdn.iconscout.com/icon/free/png-256/warning-190-457484.png" />
+        </Grid>
+        <Grid item xs={12}>
+          <h1 className="title">Oops, something went wrong! :(</h1>
+        </Grid>
+        <Grid item xs={12}>
+          <h2>
+            <ContactSupportIcon />
+            Contact our support team:
+          </h2>
+          <h3 className="hints">
+            Support email:{' '}
+            <i>
+              <b>company@support.com</b>
+            </i>
+          </h3>
+        </Grid>
+        <Grid item xs={12}>
+          <NewReleasesIcon />
+          <small>Error status: {props.errors}</small>
+        </Grid>
+      </Grid>
+    </div>
+  );
+}
+
+export default SomethingWentWrong;

--- a/src/components/error/somethingWentWrong.css
+++ b/src/components/error/somethingWentWrong.css
@@ -1,0 +1,11 @@
+.title {
+    font-size: 40px;
+}
+
+.hints {
+    font-size: 20px;
+}
+
+.info {
+    font-size: 15px;
+}

--- a/src/components/reports/Reports.tsx
+++ b/src/components/reports/Reports.tsx
@@ -2,9 +2,12 @@ import React, { useCallback, useEffect, useState } from 'react';
 import ReportCard from './ReportCard';
 import Grid from '@mui/material/Grid';
 import { getAllReports } from '../../service/ReportService';
+import SomethingWentWrong from '../error/SomethingWentWrong';
 
 function Reports() {
   const [reports, setReports] = useState([]);
+  const [error, setError] = useState(false);
+  const [errorCode, setErrorCode] = useState('');
 
   function handleGetAllReports(controller) {
     getAllReports(controller)
@@ -12,7 +15,15 @@ function Reports() {
         setReports(res.data.reports);
       })
       .catch((err) => {
-        console.log(err);
+        {
+          if (err.code === 'ERR_CANCELED') {
+            console.log(err);
+          } else {
+            console.log(err);
+            setError(true);
+            setErrorCode(err.code);
+          }
+        }
       });
   }
 
@@ -30,13 +41,19 @@ function Reports() {
   }, [getReports]);
 
   return (
-    <Grid container sx={{ flexGrow: 1 }} spacing={2}>
-      {reports.map((item, key) => (
-        <Grid item xs={12} md={4} key={key}>
-          <ReportCard report={item} />
+    <div>
+      {!error ? (
+        <Grid container sx={{ flexGrow: 1 }} spacing={2}>
+          {reports.map((item, key) => (
+            <Grid item xs={12} md={4} key={key}>
+              <ReportCard report={item} />
+            </Grid>
+          ))}
         </Grid>
-      ))}
-    </Grid>
+      ) : (
+        <SomethingWentWrong errors={errorCode} />
+      )}
+    </div>
   );
 }
 

--- a/src/components/reports/Reports.tsx
+++ b/src/components/reports/Reports.tsx
@@ -1,64 +1,27 @@
-import React, { useCallback, useEffect, useState } from 'react';
+import React from 'react';
 import ReportCard from './ReportCard';
 import Grid from '@mui/material/Grid';
-import { getAllReports } from '../../service/ReportService';
 import SomethingWentWrong from '../error/SomethingWentWrong';
+import { Report } from '../types/Types';
 
 interface Props {
-  // eslint-disable-next-line no-unused-vars
-  getLoaded: (b: boolean) => void;
+  error: boolean;
+  errorCode: string;
+  reports: Report[];
 }
 function Reports(props: Props) {
-  const [reports, setReports] = useState([]);
-  const [error, setError] = useState(false);
-  const [errorCode, setErrorCode] = useState('');
-
-  function handleGetAllReports(controller) {
-    getAllReports(controller)
-      .then((res) => {
-        setReports(res.data.reports);
-        props.getLoaded(true);
-      })
-      .catch((err) => {
-        {
-          if (err.code === 'ERR_CANCELED') {
-            console.log(err);
-            props.getLoaded(false);
-          } else {
-            console.log(err);
-            setError(true);
-            setErrorCode(err.code);
-            props.getLoaded(true);
-          }
-        }
-      });
-  }
-
-  const getReports = useCallback(async (controller) => {
-    handleGetAllReports(controller);
-  }, []);
-
-  useEffect(() => {
-    const controller = new AbortController();
-    getReports(controller);
-
-    return () => {
-      controller.abort();
-    };
-  }, [getReports]);
-
   return (
     <div>
-      {!error ? (
+      {!props.error ? (
         <Grid container sx={{ flexGrow: 1 }} spacing={2}>
-          {reports.map((item, key) => (
+          {props.reports.map((item, key) => (
             <Grid item xs={12} md={4} key={key}>
               <ReportCard report={item} />
             </Grid>
           ))}
         </Grid>
       ) : (
-        <SomethingWentWrong errors={errorCode} />
+        <SomethingWentWrong errors={props.errorCode} />
       )}
     </div>
   );

--- a/src/components/reports/Reports.tsx
+++ b/src/components/reports/Reports.tsx
@@ -4,7 +4,11 @@ import Grid from '@mui/material/Grid';
 import { getAllReports } from '../../service/ReportService';
 import SomethingWentWrong from '../error/SomethingWentWrong';
 
-function Reports() {
+interface Props {
+  // eslint-disable-next-line no-unused-vars
+  getLoaded: (b: boolean) => void;
+}
+function Reports(props: Props) {
   const [reports, setReports] = useState([]);
   const [error, setError] = useState(false);
   const [errorCode, setErrorCode] = useState('');
@@ -13,15 +17,18 @@ function Reports() {
     getAllReports(controller)
       .then((res) => {
         setReports(res.data.reports);
+        props.getLoaded(true);
       })
       .catch((err) => {
         {
           if (err.code === 'ERR_CANCELED') {
             console.log(err);
+            props.getLoaded(false);
           } else {
             console.log(err);
             setError(true);
             setErrorCode(err.code);
+            props.getLoaded(true);
           }
         }
       });

--- a/src/components/reports/ReportsTabs.tsx
+++ b/src/components/reports/ReportsTabs.tsx
@@ -1,20 +1,33 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Reports from './Reports';
 import TabContext from '@mui/lab/TabContext';
 import Box from '@mui/material/Box';
 import TabList from '@mui/lab/TabList';
 import Tab from '@mui/material/Tab';
 import TabPanel from '@mui/lab/TabPanel';
+import LinearProgress from '@mui/material/LinearProgress';
 
 function ReportsTabs() {
-  const [value, setValue] = React.useState('1');
+  const [value, setValue] = useState('1');
+  const [loaded, setLoaded] = useState(false);
 
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
+
+  function getLoaded(loaded: boolean) {
+    console.log(loaded);
+    setLoaded(loaded);
+  }
+
   return (
     <div>
       <Box sx={{ width: '100%', typography: 'body1' }}>
+        {!loaded && (
+          <Box sx={{ width: '100%' }}>
+            <LinearProgress />
+          </Box>
+        )}
         <TabContext value={value}>
           <Box sx={{ borderBottom: 1, borderColor: 'divider' }}>
             <TabList onChange={handleChange} aria-label="lab API tabs example" color="primary">
@@ -22,7 +35,7 @@ function ReportsTabs() {
             </TabList>
           </Box>
           <TabPanel value="1">
-            <Reports />
+            <Reports getLoaded={getLoaded} />
           </TabPanel>
         </TabContext>
       </Box>

--- a/src/components/reports/ReportsTabs.tsx
+++ b/src/components/reports/ReportsTabs.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 import Reports from './Reports';
 import TabContext from '@mui/lab/TabContext';
 import Box from '@mui/material/Box';
@@ -6,24 +6,56 @@ import TabList from '@mui/lab/TabList';
 import Tab from '@mui/material/Tab';
 import TabPanel from '@mui/lab/TabPanel';
 import LinearProgress from '@mui/material/LinearProgress';
+import { getAllReports } from '../../service/ReportService';
 
 function ReportsTabs() {
   const [value, setValue] = useState('1');
-  const [loaded, setLoaded] = useState(false);
+  const [reports, setReports] = useState([]);
+  const [error, setError] = useState(false);
+  const [errorCode, setErrorCode] = useState('');
+  const [isLoading, setIsLoading] = useState(true);
 
   const handleChange = (event, newValue) => {
     setValue(newValue);
   };
-
-  function getLoaded(loaded: boolean) {
-    console.log(loaded);
-    setLoaded(loaded);
+  function handleGetAllReports(controller) {
+    getAllReports(controller)
+      .then((res) => {
+        setReports(res.data.reports);
+        setIsLoading(false);
+      })
+      .catch((err) => {
+        {
+          if (err.code === 'ERR_CANCELED') {
+            console.log(err);
+            setIsLoading(true);
+          } else {
+            console.log(err);
+            setError(true);
+            setErrorCode(err.code);
+            setIsLoading(false);
+          }
+        }
+      });
   }
+
+  const getReports = useCallback(async (controller) => {
+    handleGetAllReports(controller);
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    getReports(controller);
+
+    return () => {
+      controller.abort();
+    };
+  }, [getReports]);
 
   return (
     <div>
       <Box sx={{ width: '100%', typography: 'body1' }}>
-        {!loaded && (
+        {isLoading && (
           <Box sx={{ width: '100%' }}>
             <LinearProgress />
           </Box>
@@ -35,7 +67,7 @@ function ReportsTabs() {
             </TabList>
           </Box>
           <TabPanel value="1">
-            <Reports getLoaded={getLoaded} />
+            <Reports error={error} errorCode={errorCode} reports={reports} />
           </TabPanel>
         </TabContext>
       </Box>

--- a/src/components/reports/SingleReport.tsx
+++ b/src/components/reports/SingleReport.tsx
@@ -12,10 +12,12 @@ import { getSingleReport } from '../../service/ReportService';
 import { REPORT } from '../../data/Data';
 import Snackbar from '@mui/material/Snackbar';
 import Alert from '@mui/material/Alert';
+import LinearProgress from '@mui/material/LinearProgress';
 
 function SingleReport() {
   const [report, setReport] = useState(REPORT);
   const [error, setError] = useState(false);
+  const [loaded, setLoaded] = useState(false);
 
   const { id } = useParams();
 
@@ -23,6 +25,7 @@ function SingleReport() {
     getSingleReport(id, controller)
       .then((res) => {
         setReport(res.data.report);
+        setLoaded(true);
       })
       .catch((err) => {
         if (err.code === 'ERR_CANCELED') {
@@ -30,6 +33,7 @@ function SingleReport() {
         } else {
           console.log(err);
           setError(true);
+          setLoaded(true);
         }
       });
   }
@@ -46,6 +50,11 @@ function SingleReport() {
   return (
     <div>
       <Box sx={{ flexGrow: 1 }}>
+        {!loaded && (
+          <Box sx={{ width: '100%' }}>
+            <LinearProgress />
+          </Box>
+        )}
         <Grid container>
           <Grid item xs={12}>
             <Card>

--- a/src/components/reports/SingleReport.tsx
+++ b/src/components/reports/SingleReport.tsx
@@ -10,9 +10,12 @@ import CommentsSection from '../comments/CommentsSection';
 import { useParams } from 'react-router-dom';
 import { getSingleReport } from '../../service/ReportService';
 import { REPORT } from '../../data/Data';
+import Snackbar from '@mui/material/Snackbar';
+import Alert from '@mui/material/Alert';
 
 function SingleReport() {
   const [report, setReport] = useState(REPORT);
+  const [error, setError] = useState(false);
 
   const { id } = useParams();
 
@@ -22,7 +25,12 @@ function SingleReport() {
         setReport(res.data.report);
       })
       .catch((err) => {
-        console.log(err);
+        if (err.code === 'ERR_CANCELED') {
+          console.log(err);
+        } else {
+          console.log(err);
+          setError(true);
+        }
       });
   }
 
@@ -69,6 +77,16 @@ function SingleReport() {
           </Grid>
         </Grid>
       </Box>
+      {error && (
+        <Snackbar
+          anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }}
+          open={error}
+          autoHideDuration={5000}>
+          <Alert severity="error" sx={{ width: '100%' }}>
+            There has been a problem with loading the data!
+          </Alert>
+        </Snackbar>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
Created global error page when a page can't be loaded at al which can be used through the app.
Implemented error notifications on failed data load in the single report page.

Global error page:
![image](https://user-images.githubusercontent.com/56558009/207088697-e720e8eb-676d-4297-ae9e-05f1195a9eda.png)

Notifications:
![image](https://user-images.githubusercontent.com/56558009/207088917-84532a1d-5767-4c69-9d38-1a208afa4a3b.png)

Loaders:
![image](https://user-images.githubusercontent.com/56558009/207264032-8dfc1c7a-e40d-45b7-80de-c72549319626.png)

