### PR TITLE
Separated headline and main text

### DIFF
--- a/src/components/reports/ReportCard.tsx
+++ b/src/components/reports/ReportCard.tsx
@@ -28,7 +28,7 @@ function ReportCard(props: Props) {
               {props.report.title}
             </Typography>
             <Typography variant="body2" color="text.secondary">
-              {props.report.text}
+              {props.report.headline_text}
             </Typography>
           </CardContent>
           <CardActions>

--- a/src/components/reports/SingleReport.tsx
+++ b/src/components/reports/SingleReport.tsx
@@ -67,7 +67,7 @@ function SingleReport() {
                   <h1>{report.title}</h1>
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
-                  {report.text}
+                  {report.main_text}
                 </Typography>
                 <Typography variant="body2" color="text.secondary">
                   <p>Author - {report.author}</p>

--- a/src/components/types/Types.ts
+++ b/src/components/types/Types.ts
@@ -4,7 +4,6 @@ export interface Report {
   author: string;
   headline_text: string;
   photo: string;
-
   main_text: string;
 }
 

--- a/src/components/types/Types.ts
+++ b/src/components/types/Types.ts
@@ -2,8 +2,10 @@ export interface Report {
   report_id: number;
   title: string;
   author: string;
-  text: string;
+  headline_text: string;
   photo: string;
+
+  main_text: string;
 }
 
 export interface SingleComment {

--- a/src/data/Data.ts
+++ b/src/data/Data.ts
@@ -31,7 +31,8 @@ export const REPORT = {
   title: '',
   author: '',
   text: '',
-  photo: ''
+  photo: '',
+  main_text: ''
 };
 
 export const SEND_EMAIL = {


### PR DESCRIPTION
The headline and main text were separated to two different columns in the database.
The headline is shown on the landing page and the main text now shows inside of the article.

Headline text:
![image](https://user-images.githubusercontent.com/56558009/207606167-5e287b85-8305-4575-b570-4e0e9af75bbd.png)
